### PR TITLE
Use keymap events

### DIFF
--- a/lib/command-logger-view.coffee
+++ b/lib/command-logger-view.coffee
@@ -101,8 +101,8 @@ class CommandLoggerView extends ScrollView
 
   addTreeMap: ->
     root =
-     name: 'All'
-     children: @createNodes()
+      name: 'All'
+      children: @createNodes()
     node = root
 
     @treeMap.empty()
@@ -137,7 +137,7 @@ class CommandLoggerView extends ScrollView
        .attr('height', (d) -> ky * d.dy - 1)
 
       t.select('.command-logger-node-text div')
-       .attr('style', (d) -> "height:#{ky * d.dy - 1}px;width:#{kx * d.dx - 1}px")
+        .attr('style', (d) -> "height:#{ky * d.dy - 1}px;width:#{kx * d.dx - 1}px")
 
       node = d
       d3.event.stopPropagation()

--- a/lib/command-logger.coffee
+++ b/lib/command-logger.coffee
@@ -23,15 +23,12 @@ module.exports =
         @eventLog[eventName] = eventNameLog
       eventNameLog.count++
       eventNameLog.lastRun = Date.now()
-    trigger = $.fn.trigger
-    @originalTrigger = trigger
-    $.fn.trigger = (event) ->
-      eventName = event.type ? event
-      registerTriggeredEvent(eventName) if $(this).events()[eventName]
-      trigger.apply(this, arguments)
+
+    atom.keymap.on 'matched.command-logger', ({binding}) ->
+      registerTriggeredEvent(binding.command)
 
   deactivate: ->
-    $.fn.trigger = @originalTrigger if @originalTrigger?
+    atom.keymap.off('.command-logger')
     @eventLog = {}
 
   serialize: ->

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   },
   "repository": "https://github.com/kevinsawicki/command-logger",
   "engines": {
-    "atom": "*"
+    "atom": ">0.82.0"
   }
 }

--- a/spec/command-logger-spec.coffee
+++ b/spec/command-logger-spec.coffee
@@ -63,6 +63,7 @@ describe "CommandLogger", ->
 
   describe "command-logger:open", ->
     it "opens the command logger in a pane", ->
+      triggerKey('tab')
       atom.workspaceView.trigger 'command-logger:open'
 
       waitsFor ->

--- a/spec/command-logger-spec.coffee
+++ b/spec/command-logger-spec.coffee
@@ -3,8 +3,8 @@
 describe "CommandLogger", ->
   [commandLogger, editor] = []
 
-  triggerBackspaceCommand = ->
-    editor.trigger(window.keydownEvent('backspace'))
+  triggerKey = (key) ->
+    editor.trigger(window.keydownEvent(key))
 
   beforeEach ->
     atom.workspaceView = new WorkspaceView
@@ -21,16 +21,16 @@ describe "CommandLogger", ->
       commandLogger.eventLog = {}
 
   describe "when a command is triggered", ->
-    it "records the number of times the commanxd is triggered", ->
+    it "records the number of times the command is triggered", ->
       expect(commandLogger.eventLog['core:backspace']).toBeUndefined()
-      triggerBackspaceCommand()
+      triggerKey('backspace')
       expect(commandLogger.eventLog['core:backspace'].count).toBe 1
-      triggerBackspaceCommand()
+      triggerKey('backspace')
       expect(commandLogger.eventLog['core:backspace'].count).toBe 2
 
     it "records the date the command was last triggered", ->
       expect(commandLogger.eventLog['core:backspace']).toBeUndefined()
-      triggerBackspaceCommand()
+      triggerKey('backspace')
       lastRun = commandLogger.eventLog['core:backspace'].lastRun
       expect(lastRun).toBeGreaterThan 0
       start = Date.now()
@@ -38,34 +38,31 @@ describe "CommandLogger", ->
         Date.now() > start
 
       runs ->
-        triggerBackspaceCommand()
+        triggerKey('backspace')
         expect(commandLogger.eventLog['core:backspace'].lastRun).toBeGreaterThan lastRun
 
   describe "when the data is cleared", ->
     it "removes all triggered events from the log", ->
       expect(commandLogger.eventLog['core:backspace']).toBeUndefined()
-      triggerBackspaceCommand()
+      triggerKey('backspace')
       expect(commandLogger.eventLog['core:backspace'].count).toBe 1
       atom.workspaceView.trigger 'command-logger:clear-data'
       expect(commandLogger.eventLog['core:backspace']).toBeUndefined()
 
   describe "when an event is ignored", ->
-    fit "does not create a node for that event", ->
-      editor.trigger 'editor:delete-line'
-      triggerBackspaceCommand()
+    it "does not create a node for that event", ->
+      triggerKey('backspace')
       commandLoggerView = commandLogger.createView()
-      # commandLoggerView.ignoredEvents.push 'editor:delete-line'
+      commandLoggerView.ignoredEvents = ['core:backspace']
       commandLoggerView.eventLog = commandLogger.eventLog
       nodes = commandLoggerView.createNodes()
 
-      console.log nodes
-      for {name, children} in nodes# when name is 'Editor'
+      for {name, children} in nodes
         for child in children
-          expect(child.name.indexOf('Delete Line')).toBe -1
+          expect(child.name.indexOf('Backspace')).toBe -1
 
   describe "command-logger:open", ->
     it "opens the command logger in a pane", ->
-      atom.workspaceView.attachToDom()
       atom.workspaceView.trigger 'command-logger:open'
 
       waitsFor ->

--- a/spec/command-logger-spec.coffee
+++ b/spec/command-logger-spec.coffee
@@ -3,10 +3,15 @@
 describe "CommandLogger", ->
   [commandLogger, editor] = []
 
+  triggerBackspaceCommand = ->
+    editor.trigger(window.keydownEvent('backspace'))
+
   beforeEach ->
     atom.workspaceView = new WorkspaceView
     atom.workspaceView.openSync('sample.js')
+    atom.workspaceView.attachToDom()
     editor = atom.workspaceView.getActiveView()
+    editor.enableKeymap()
 
     waitsForPromise ->
       atom.packages.activatePackage('command-logger')
@@ -16,16 +21,16 @@ describe "CommandLogger", ->
       commandLogger.eventLog = {}
 
   describe "when a command is triggered", ->
-    it "records the number of times the command is triggered", ->
+    it "records the number of times the commanxd is triggered", ->
       expect(commandLogger.eventLog['core:backspace']).toBeUndefined()
-      editor.trigger 'core:backspace'
+      triggerBackspaceCommand()
       expect(commandLogger.eventLog['core:backspace'].count).toBe 1
-      editor.trigger 'core:backspace'
+      triggerBackspaceCommand()
       expect(commandLogger.eventLog['core:backspace'].count).toBe 2
 
     it "records the date the command was last triggered", ->
       expect(commandLogger.eventLog['core:backspace']).toBeUndefined()
-      editor.trigger 'core:backspace'
+      triggerBackspaceCommand()
       lastRun = commandLogger.eventLog['core:backspace'].lastRun
       expect(lastRun).toBeGreaterThan 0
       start = Date.now()
@@ -33,25 +38,28 @@ describe "CommandLogger", ->
         Date.now() > start
 
       runs ->
-        editor.trigger 'core:backspace'
+        triggerBackspaceCommand()
         expect(commandLogger.eventLog['core:backspace'].lastRun).toBeGreaterThan lastRun
 
   describe "when the data is cleared", ->
     it "removes all triggered events from the log", ->
       expect(commandLogger.eventLog['core:backspace']).toBeUndefined()
-      editor.trigger 'core:backspace'
+      triggerBackspaceCommand()
       expect(commandLogger.eventLog['core:backspace'].count).toBe 1
       atom.workspaceView.trigger 'command-logger:clear-data'
       expect(commandLogger.eventLog['core:backspace']).toBeUndefined()
 
   describe "when an event is ignored", ->
-    it "does not create a node for that event", ->
-      commandLoggerView = commandLogger.createView()
-      commandLoggerView.ignoredEvents.push 'editor:delete-line'
+    fit "does not create a node for that event", ->
       editor.trigger 'editor:delete-line'
+      triggerBackspaceCommand()
+      commandLoggerView = commandLogger.createView()
+      # commandLoggerView.ignoredEvents.push 'editor:delete-line'
       commandLoggerView.eventLog = commandLogger.eventLog
       nodes = commandLoggerView.createNodes()
-      for {name, children} in nodes when name is 'Editor'
+
+      console.log nodes
+      for {name, children} in nodes# when name is 'Editor'
         for child in children
           expect(child.name.indexOf('Delete Line')).toBe -1
 


### PR DESCRIPTION
Command Palette used to take over `$.fn.trigger`, but that is not needed anymore since Atom emits events when a command is triggered via the keyboard.

The downside to this is it won't log events triggered by the command palette.
